### PR TITLE
Demo experience, shipping streaks, public pages & landing overhaul

### DIFF
--- a/app/(dashboard)/dashboard/projects/[id]/build/page.tsx
+++ b/app/(dashboard)/dashboard/projects/[id]/build/page.tsx
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react'
 import { useParams, useRouter } from 'next/navigation'
 import { Check, Clock, Zap, Code, TrendingUp, ChevronRight, Loader2, Sparkles } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
+import DailyCheckInModal from '@/components/streak/DailyCheckInModal'
+import StreakWidget from '@/components/streak/StreakWidget'
+import { shouldShowCheckIn } from '@/lib/streak/checkInPrompt'
 
 interface Task {
   id: string
@@ -21,6 +24,9 @@ interface Project {
   name: string
   phase: string
   tasks: Task[]
+  current_streak?: number
+  longest_streak?: number
+  last_ship_date?: string | null
 }
 
 const pipelineSteps = [
@@ -41,6 +47,7 @@ export default function BuildPage() {
   const [advancing, setAdvancing] = useState(false)
   const [updatingTask, setUpdatingTask] = useState<string | null>(null)
   const [generatingCode, setGeneratingCode] = useState<string | null>(null)
+  const [showCheckIn, setShowCheckIn] = useState(false)
 
   useEffect(() => {
     const fetchProject = async () => {
@@ -52,9 +59,36 @@ export default function BuildPage() {
         .single()
       setProject(data)
       setLoading(false)
+
+      if (data && shouldShowCheckIn(data.last_ship_date)) {
+        const timer = setTimeout(() => setShowCheckIn(true), 3000)
+        return () => clearTimeout(timer)
+      }
     }
     fetchProject()
   }, [id])
+
+  const handleLogShip = async (description: string) => {
+    const res = await fetch('/api/ships/log', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ projectId: id, description }),
+    })
+    const data = await res.json()
+    if (data.success) {
+      setProject((prev) =>
+        prev
+          ? {
+              ...prev,
+              current_streak: data.streak,
+              longest_streak: data.longestStreak,
+              last_ship_date: new Date().toISOString().split('T')[0],
+            }
+          : prev
+      )
+    }
+    setShowCheckIn(false)
+  }
 
   const toggleTask = async (task: Task) => {
     setUpdatingTask(task.id)
@@ -120,6 +154,16 @@ export default function BuildPage() {
 
   return (
     <div className="px-6 py-10 max-w-5xl mx-auto space-y-8">
+      {/* Daily check-in modal */}
+      {showCheckIn && project && (
+        <DailyCheckInModal
+          projectName={project.name}
+          currentStreak={project.current_streak ?? 0}
+          onClose={() => setShowCheckIn(false)}
+          onSubmit={handleLogShip}
+        />
+      )}
+
       {/* Header */}
       <div>
         <p
@@ -227,6 +271,14 @@ export default function BuildPage() {
           </div>
         ))}
       </div>
+
+      {/* Streak Widget */}
+      {(project.current_streak ?? 0) > 0 || project.last_ship_date ? (
+        <StreakWidget
+          currentStreak={project.current_streak ?? 0}
+          longestStreak={project.longest_streak ?? 0}
+        />
+      ) : null}
 
       {/* Task List */}
       <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">

--- a/app/api/og/route.tsx
+++ b/app/api/og/route.tsx
@@ -1,0 +1,85 @@
+import { ImageResponse } from 'next/og'
+import { NextRequest } from 'next/server'
+
+export const runtime = 'edge'
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url)
+  const title = searchParams.get('title') ?? 'Untitled Project'
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: '100%',
+          width: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #7c3aed 0%, #2563eb 100%)',
+          padding: '60px',
+        }}
+      >
+        {/* Logo */}
+        <div style={{ display: 'flex', alignItems: 'center', marginBottom: '32px' }}>
+          <div
+            style={{
+              fontSize: '18px',
+              fontWeight: 700,
+              color: 'rgba(255,255,255,0.7)',
+              letterSpacing: '4px',
+              textTransform: 'uppercase',
+            }}
+          >
+            ✦✦ YACHT LABS
+          </div>
+        </div>
+
+        {/* Title */}
+        <div
+          style={{
+            fontSize: title.length > 30 ? 56 : 72,
+            fontWeight: 800,
+            color: '#ffffff',
+            textAlign: 'center',
+            lineHeight: 1.1,
+            marginBottom: '24px',
+            maxWidth: '900px',
+          }}
+        >
+          {title}
+        </div>
+
+        {/* Subtitle */}
+        <div
+          style={{
+            fontSize: '28px',
+            color: 'rgba(255,255,255,0.85)',
+            textAlign: 'center',
+            marginBottom: '40px',
+          }}
+        >
+          Built with Yacht Labs
+        </div>
+
+        {/* Pipeline badge */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '12px',
+            padding: '12px 28px',
+            background: 'rgba(255,255,255,0.15)',
+            borderRadius: '100px',
+            fontSize: '20px',
+            color: 'rgba(255,255,255,0.9)',
+          }}
+        >
+          Think → Build → Ship → Listen → Repeat
+        </div>
+      </div>
+    ),
+    { width: 1200, height: 630 }
+  )
+}

--- a/app/api/projects/[id]/share/route.ts
+++ b/app/api/projects/[id]/share/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+
+// id param here is the project slug (used for public pages)
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: slug } = await params
+    const cookieStore = await cookies()
+    const supabase = createClient(cookieStore)
+
+    // platform is logged but not stored — extend later for analytics
+    await request.json().catch(() => {})
+
+    const { error } = await supabase.rpc('increment_project_shares', {
+      project_slug: slug,
+    })
+
+    if (error) console.error('increment_project_shares error:', error)
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('share route error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/projects/[id]/view/route.ts
+++ b/app/api/projects/[id]/view/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+
+// id param here is the project slug (used for public pages)
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id: slug } = await params
+    const cookieStore = await cookies()
+    const supabase = createClient(cookieStore)
+
+    const { error } = await supabase.rpc('increment_project_views', {
+      project_slug: slug,
+    })
+
+    if (error) console.error('increment_project_views error:', error)
+
+    return NextResponse.json({ success: true })
+  } catch (err) {
+    console.error('view route error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/projects/[id]/visibility/route.ts
+++ b/app/api/projects/[id]/visibility/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { cookies } from 'next/headers'
 import { createClient } from '@/utils/supabase/server'
+import { generateSlug, ensureUniqueSlug } from '@/lib/utils/slugify'
 
 export async function PATCH(
   request: NextRequest,
@@ -19,30 +20,38 @@ export async function PATCH(
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { is_public, slug } = await request.json()
+    const { is_public, custom_slug } = await request.json()
 
-    // Verify project belongs to user
-    const { data: project } = await supabase
+    const { data: project, error: projectError } = await supabase
       .from('projects')
-      .select('id, user_id')
+      .select('id, name, user_id, slug')
       .eq('id', id)
       .eq('user_id', user.id)
       .single()
 
-    if (!project) {
-      return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+    if (projectError || !project) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
     }
 
-    const updates: Record<string, unknown> = { is_public }
-    if (slug) updates.slug = slug
+    let slug: string | null = project.slug
 
-    const { error } = await supabase.from('projects').update(updates).eq('id', id)
+    if (is_public) {
+      const base = custom_slug ? generateSlug(custom_slug) : (project.slug ?? generateSlug(project.name))
+      slug = await ensureUniqueSlug(supabase, base, id)
+    }
+
+    const { data, error } = await supabase
+      .from('projects')
+      .update({ is_public, slug })
+      .eq('id', id)
+      .select()
+      .single()
 
     if (error) {
       return NextResponse.json({ error: error.message }, { status: 500 })
     }
 
-    return NextResponse.json({ success: true, is_public, slug })
+    return NextResponse.json({ success: true, project: data })
   } catch (err) {
     console.error('visibility route error:', err)
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/app/api/projects/[id]/visibility/route.ts
+++ b/app/api/projects/[id]/visibility/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const cookieStore = await cookies()
+    const supabase = createClient(cookieStore)
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { is_public, slug } = await request.json()
+
+    // Verify project belongs to user
+    const { data: project } = await supabase
+      .from('projects')
+      .select('id, user_id')
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .single()
+
+    if (!project) {
+      return NextResponse.json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const updates: Record<string, unknown> = { is_public }
+    if (slug) updates.slug = slug
+
+    const { error } = await supabase.from('projects').update(updates).eq('id', id)
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 })
+    }
+
+    return NextResponse.json({ success: true, is_public, slug })
+  } catch (err) {
+    console.error('visibility route error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/api/ships/log/route.ts
+++ b/app/api/ships/log/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { cookies } from 'next/headers'
+import { createClient } from '@/utils/supabase/server'
+import { calculateStreak } from '@/lib/streak/checkInPrompt'
+
+export async function POST(request: NextRequest) {
+  try {
+    const cookieStore = await cookies()
+    const supabase = createClient(cookieStore)
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { projectId, description } = await request.json()
+
+    if (!projectId || !description?.trim()) {
+      return NextResponse.json({ error: 'projectId and description are required' }, { status: 400 })
+    }
+
+    const today = new Date().toISOString().split('T')[0]
+
+    // Prevent duplicate check-ins on the same day
+    const { data: existing } = await supabase
+      .from('daily_ships')
+      .select('id')
+      .eq('project_id', projectId)
+      .eq('ship_date', today)
+      .single()
+
+    if (existing) {
+      return NextResponse.json({ error: 'Already logged today' }, { status: 409 })
+    }
+
+    // Insert ship log
+    const { error: shipError } = await supabase.from('daily_ships').insert({
+      user_id: user.id,
+      project_id: projectId,
+      ship_description: description.trim(),
+      ship_date: today,
+    })
+
+    if (shipError) {
+      return NextResponse.json({ error: shipError.message }, { status: 500 })
+    }
+
+    // Fetch project to compute new streak
+    const { data: project } = await supabase
+      .from('projects')
+      .select('last_ship_date, current_streak, longest_streak')
+      .eq('id', projectId)
+      .single()
+
+    const newStreak = calculateStreak(project?.last_ship_date, project?.current_streak ?? 0)
+    const newLongest = Math.max(newStreak, project?.longest_streak ?? 0)
+
+    await supabase
+      .from('projects')
+      .update({
+        last_ship_date: today,
+        current_streak: newStreak,
+        longest_streak: newLongest,
+      })
+      .eq('id', projectId)
+
+    return NextResponse.json({ success: true, streak: newStreak, longestStreak: newLongest })
+  } catch (err) {
+    console.error('ships/log error:', err)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -1,38 +1,8 @@
 import { notFound } from 'next/navigation'
 import { cookies } from 'next/headers'
-import Link from 'next/link'
-import { Check, Clock, ChevronRight, Eye } from 'lucide-react'
 import { createClient } from '@/utils/supabase/server'
+import PublicProjectView from '@/components/public/PublicProjectView'
 import type { Metadata } from 'next'
-
-interface DailyShip {
-  id: string
-  ship_description: string
-  ship_date: string
-}
-
-interface Task {
-  id: string
-  title: string
-  description: string
-  status: string
-  phase: string
-  estimated_hours: number
-  actual_hours: number | null
-}
-
-interface Project {
-  id: string
-  name: string
-  description: string
-  phase: string
-  created_at: string
-  view_count: number
-  tasks: Task[]
-  daily_ships: DailyShip[]
-  current_streak: number
-  longest_streak: number
-}
 
 export async function generateMetadata({
   params,
@@ -50,21 +20,19 @@ export async function generateMetadata({
     .eq('is_public', true)
     .single()
 
-  if (!data) return {}
+  if (!data) return { title: 'Project Not Found' }
+
+  const title = `${data.name} — Built with Yacht Labs`
+  const description =
+    data.description ?? `${data.name} — shipped using the Yacht Labs framework`
+  const ogImage = `/api/og?title=${encodeURIComponent(data.name)}`
 
   return {
-    title: `${data.name} — Built with Yacht Labs`,
-    description: data.description ?? `Follow ${data.name}'s shipping journey on Yacht Labs.`,
+    title,
+    description,
+    openGraph: { title, description, images: [ogImage] },
+    twitter: { card: 'summary_large_image', title, description, images: [ogImage] },
   }
-}
-
-const phaseOrder = ['think', 'build', 'ship', 'listen', 'repeat']
-const phaseColors: Record<string, string> = {
-  think: '#8b5cf6',
-  build: '#3b82f6',
-  ship: '#f97316',
-  listen: '#22c55e',
-  repeat: '#f59e0b',
 }
 
 export default async function PublicProjectPage({
@@ -81,246 +49,19 @@ export default async function PublicProjectPage({
     .select('*, tasks(*), daily_ships(*)')
     .eq('slug', slug)
     .eq('is_public', true)
-    .single<Project>()
+    .single()
 
   if (error || !project) notFound()
 
-  // Increment view count (fire and forget)
-  supabase
-    .from('projects')
-    .update({ view_count: (project.view_count ?? 0) + 1 })
-    .eq('id', project.id)
-    .then(() => {})
-
-  const tasks: Task[] = project.tasks ?? []
-  const ships: DailyShip[] = project.daily_ships ?? []
-  const completedTasks = tasks.filter((t) => t.status === 'done').length
-  const progress = tasks.length > 0 ? Math.round((completedTasks / tasks.length) * 100) : 0
-  const daysElapsed = Math.floor(
-    (Date.now() - new Date(project.created_at).getTime()) / (1000 * 60 * 60 * 24)
+  // Sort tasks by order_index, ships newest-first
+  project.tasks?.sort(
+    (a: { order_index?: number }, b: { order_index?: number }) =>
+      (a.order_index ?? 0) - (b.order_index ?? 0)
   )
-  const currentPhaseIdx = phaseOrder.indexOf(project.phase)
-
-  return (
-    <div className="min-h-screen bg-[#0a0a0a]">
-      {/* Nav */}
-      <nav className="flex items-center justify-between px-6 py-4 border-b border-[#1a1a1a]">
-        <Link
-          href="/"
-          className="text-xs font-bold tracking-widest uppercase text-white"
-          style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-        >
-          ✦✦ YACHT LABS
-        </Link>
-        <Link
-          href="/signup"
-          className="px-4 py-2 bg-white text-black text-xs font-bold uppercase tracking-widest rounded-lg hover:bg-gray-100 transition-colors"
-          style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-        >
-          Start Your Project
-        </Link>
-      </nav>
-
-      <div className="max-w-4xl mx-auto px-6 py-10 space-y-8">
-        {/* Header */}
-        <div>
-          <div className="flex items-center gap-3 mb-3 flex-wrap">
-            <span
-              className="text-xs font-bold px-2 py-0.5 rounded uppercase tracking-wider"
-              style={{
-                backgroundColor: `${phaseColors[project.phase] ?? '#888888'}22`,
-                color: phaseColors[project.phase] ?? '#888888',
-                fontFamily: 'var(--font-space-mono), monospace',
-              }}
-            >
-              {project.phase} phase
-            </span>
-            {(project.current_streak ?? 0) > 0 && (
-              <span className="text-xs text-[#f59e0b]">
-                🔥 {project.current_streak}-day streak
-              </span>
-            )}
-          </div>
-          <h1
-            className="text-3xl sm:text-4xl font-bold text-white uppercase tracking-widest mb-3"
-            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-          >
-            {project.name}
-          </h1>
-          {project.description && (
-            <p className="text-[#888888] text-sm max-w-xl leading-relaxed">{project.description}</p>
-          )}
-          <div className="flex items-center gap-5 mt-3 text-xs text-[#555555]">
-            <span className="flex items-center gap-1.5">
-              <Clock size={11} />
-              {daysElapsed === 0 ? 'Started today' : `${daysElapsed}d in progress`}
-            </span>
-            <span>{progress}% complete</span>
-            {(project.view_count ?? 0) > 0 && (
-              <span className="flex items-center gap-1.5">
-                <Eye size={11} />
-                {project.view_count} views
-              </span>
-            )}
-          </div>
-        </div>
-
-        {/* Execution Pipeline */}
-        <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
-          <h2
-            className="text-xs font-bold text-[#888888] uppercase tracking-widest mb-4"
-            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-          >
-            EXECUTION PIPELINE
-          </h2>
-          <div className="flex items-center gap-2 overflow-x-auto pb-1">
-            {phaseOrder.map((phase, idx) => {
-              const isComplete = idx < currentPhaseIdx
-              const isActive = idx === currentPhaseIdx
-              return (
-                <div key={phase} className="flex items-center gap-2 flex-shrink-0">
-                  <div
-                    className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-bold uppercase tracking-wider ${
-                      isComplete
-                        ? 'bg-[#22c55e22] text-[#22c55e] border border-[#22c55e44]'
-                        : isActive
-                        ? 'bg-[#3b82f622] text-[#3b82f6] border-2 border-[#3b82f6]'
-                        : 'bg-[#0a0a0a] text-[#555555] border border-[#222222]'
-                    }`}
-                    style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-                  >
-                    {isComplete && <Check size={11} />}
-                    {phase}
-                  </div>
-                  {idx < phaseOrder.length - 1 && (
-                    <ChevronRight
-                      size={14}
-                      className={isComplete ? 'text-[#22c55e]' : 'text-[#333333]'}
-                    />
-                  )}
-                </div>
-              )
-            })}
-          </div>
-        </div>
-
-        {/* Progress */}
-        {tasks.length > 0 && (
-          <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
-            <div className="flex items-center justify-between mb-4">
-              <h2
-                className="text-sm font-bold text-white uppercase tracking-widest"
-                style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-              >
-                BUILD PROGRESS ({completedTasks}/{tasks.length})
-              </h2>
-              <span className="text-xs text-[#888888]">{progress}%</span>
-            </div>
-            <div className="h-1.5 bg-[#1a1a1a] rounded-full mb-6 overflow-hidden">
-              <div
-                className="h-full bg-[#3b82f6] rounded-full"
-                style={{ width: `${progress}%` }}
-              />
-            </div>
-            <div className="space-y-2">
-              {tasks
-                .filter((t) => t.status === 'done')
-                .map((task) => (
-                  <div
-                    key={task.id}
-                    className="flex items-start gap-3 bg-[#22c55e08] rounded-lg px-3 py-2.5"
-                  >
-                    <div className="flex-shrink-0 w-4 h-4 rounded bg-[#22c55e] flex items-center justify-center mt-0.5">
-                      <Check size={9} className="text-white" />
-                    </div>
-                    <div className="flex-1 min-w-0">
-                      <p className="text-sm text-[#888888] line-through">{task.title}</p>
-                    </div>
-                    {task.actual_hours && (
-                      <span className="text-xs text-[#444444] flex-shrink-0">{task.actual_hours}h</span>
-                    )}
-                  </div>
-                ))}
-              {tasks
-                .filter((t) => t.status !== 'done')
-                .slice(0, 3)
-                .map((task) => (
-                  <div
-                    key={task.id}
-                    className="flex items-center gap-3 bg-[#0a0a0a] rounded-lg px-3 py-2.5"
-                  >
-                    <div className="flex-shrink-0 w-4 h-4 rounded border-2 border-[#333333]" />
-                    <p className="text-sm text-white">{task.title}</p>
-                  </div>
-                ))}
-            </div>
-          </div>
-        )}
-
-        {/* Ship Log */}
-        {ships.length > 0 && (
-          <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
-            <h2
-              className="text-sm font-bold text-white uppercase tracking-widest mb-4"
-              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-            >
-              SHIPPING LOG ({ships.length} entries)
-            </h2>
-            <div className="space-y-3">
-              {[...ships]
-                .sort((a, b) => new Date(b.ship_date).getTime() - new Date(a.ship_date).getTime())
-                .map((ship) => (
-                  <div key={ship.id} className="flex gap-4 bg-[#0a0a0a] rounded-lg px-4 py-3">
-                    <div className="flex-shrink-0 text-right min-w-[72px]">
-                      <p
-                        className="text-xs text-[#555555] uppercase tracking-wider"
-                        style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-                      >
-                        {new Date(ship.ship_date).toLocaleDateString('en-US', {
-                          month: 'short',
-                          day: 'numeric',
-                        })}
-                      </p>
-                    </div>
-                    <p className="text-sm text-[#888888] leading-relaxed">{ship.ship_description}</p>
-                  </div>
-                ))}
-            </div>
-          </div>
-        )}
-
-        {/* CTA */}
-        <div className="bg-[#111111] border border-[#8b5cf644] rounded-xl p-8 text-center">
-          <p
-            className="text-sm font-bold text-white uppercase tracking-widest mb-2"
-            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-          >
-            Want to ship like this?
-          </p>
-          <p className="text-xs text-[#888888] mb-6 max-w-sm mx-auto">
-            Yacht Labs gives you the framework, accountability, and AI tools to go from idea to shipped product in days.
-          </p>
-          <Link
-            href="/signup"
-            className="inline-flex items-center gap-2 bg-white text-black font-bold text-xs uppercase tracking-widest py-3 px-6 rounded-lg hover:bg-gray-100 transition-colors"
-            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
-          >
-            Start Your Project Free
-            <ChevronRight size={14} />
-          </Link>
-        </div>
-      </div>
-
-      {/* Footer */}
-      <footer className="border-t border-[#1a1a1a] py-6 mt-12">
-        <p className="text-center text-xs text-[#555555]" style={{ fontFamily: 'var(--font-space-mono), monospace' }}>
-          Built with{' '}
-          <Link href="/" className="text-[#8b5cf6] hover:text-[#a78bfa] transition-colors">
-            ✦✦ YACHT LABS
-          </Link>{' '}
-          · Think · Build · Ship · Listen · Repeat
-        </p>
-      </footer>
-    </div>
+  project.daily_ships?.sort(
+    (a: { ship_date: string }, b: { ship_date: string }) =>
+      new Date(b.ship_date).getTime() - new Date(a.ship_date).getTime()
   )
+
+  return <PublicProjectView project={project} />
 }

--- a/app/p/[slug]/page.tsx
+++ b/app/p/[slug]/page.tsx
@@ -1,0 +1,326 @@
+import { notFound } from 'next/navigation'
+import { cookies } from 'next/headers'
+import Link from 'next/link'
+import { Check, Clock, ChevronRight, Eye } from 'lucide-react'
+import { createClient } from '@/utils/supabase/server'
+import type { Metadata } from 'next'
+
+interface DailyShip {
+  id: string
+  ship_description: string
+  ship_date: string
+}
+
+interface Task {
+  id: string
+  title: string
+  description: string
+  status: string
+  phase: string
+  estimated_hours: number
+  actual_hours: number | null
+}
+
+interface Project {
+  id: string
+  name: string
+  description: string
+  phase: string
+  created_at: string
+  view_count: number
+  tasks: Task[]
+  daily_ships: DailyShip[]
+  current_streak: number
+  longest_streak: number
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+  const cookieStore = await cookies()
+  const supabase = createClient(cookieStore)
+
+  const { data } = await supabase
+    .from('projects')
+    .select('name, description')
+    .eq('slug', slug)
+    .eq('is_public', true)
+    .single()
+
+  if (!data) return {}
+
+  return {
+    title: `${data.name} — Built with Yacht Labs`,
+    description: data.description ?? `Follow ${data.name}'s shipping journey on Yacht Labs.`,
+  }
+}
+
+const phaseOrder = ['think', 'build', 'ship', 'listen', 'repeat']
+const phaseColors: Record<string, string> = {
+  think: '#8b5cf6',
+  build: '#3b82f6',
+  ship: '#f97316',
+  listen: '#22c55e',
+  repeat: '#f59e0b',
+}
+
+export default async function PublicProjectPage({
+  params,
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+  const cookieStore = await cookies()
+  const supabase = createClient(cookieStore)
+
+  const { data: project, error } = await supabase
+    .from('projects')
+    .select('*, tasks(*), daily_ships(*)')
+    .eq('slug', slug)
+    .eq('is_public', true)
+    .single<Project>()
+
+  if (error || !project) notFound()
+
+  // Increment view count (fire and forget)
+  supabase
+    .from('projects')
+    .update({ view_count: (project.view_count ?? 0) + 1 })
+    .eq('id', project.id)
+    .then(() => {})
+
+  const tasks: Task[] = project.tasks ?? []
+  const ships: DailyShip[] = project.daily_ships ?? []
+  const completedTasks = tasks.filter((t) => t.status === 'done').length
+  const progress = tasks.length > 0 ? Math.round((completedTasks / tasks.length) * 100) : 0
+  const daysElapsed = Math.floor(
+    (Date.now() - new Date(project.created_at).getTime()) / (1000 * 60 * 60 * 24)
+  )
+  const currentPhaseIdx = phaseOrder.indexOf(project.phase)
+
+  return (
+    <div className="min-h-screen bg-[#0a0a0a]">
+      {/* Nav */}
+      <nav className="flex items-center justify-between px-6 py-4 border-b border-[#1a1a1a]">
+        <Link
+          href="/"
+          className="text-xs font-bold tracking-widest uppercase text-white"
+          style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+        >
+          ✦✦ YACHT LABS
+        </Link>
+        <Link
+          href="/signup"
+          className="px-4 py-2 bg-white text-black text-xs font-bold uppercase tracking-widest rounded-lg hover:bg-gray-100 transition-colors"
+          style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+        >
+          Start Your Project
+        </Link>
+      </nav>
+
+      <div className="max-w-4xl mx-auto px-6 py-10 space-y-8">
+        {/* Header */}
+        <div>
+          <div className="flex items-center gap-3 mb-3 flex-wrap">
+            <span
+              className="text-xs font-bold px-2 py-0.5 rounded uppercase tracking-wider"
+              style={{
+                backgroundColor: `${phaseColors[project.phase] ?? '#888888'}22`,
+                color: phaseColors[project.phase] ?? '#888888',
+                fontFamily: 'var(--font-space-mono), monospace',
+              }}
+            >
+              {project.phase} phase
+            </span>
+            {(project.current_streak ?? 0) > 0 && (
+              <span className="text-xs text-[#f59e0b]">
+                🔥 {project.current_streak}-day streak
+              </span>
+            )}
+          </div>
+          <h1
+            className="text-3xl sm:text-4xl font-bold text-white uppercase tracking-widest mb-3"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            {project.name}
+          </h1>
+          {project.description && (
+            <p className="text-[#888888] text-sm max-w-xl leading-relaxed">{project.description}</p>
+          )}
+          <div className="flex items-center gap-5 mt-3 text-xs text-[#555555]">
+            <span className="flex items-center gap-1.5">
+              <Clock size={11} />
+              {daysElapsed === 0 ? 'Started today' : `${daysElapsed}d in progress`}
+            </span>
+            <span>{progress}% complete</span>
+            {(project.view_count ?? 0) > 0 && (
+              <span className="flex items-center gap-1.5">
+                <Eye size={11} />
+                {project.view_count} views
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Execution Pipeline */}
+        <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
+          <h2
+            className="text-xs font-bold text-[#888888] uppercase tracking-widest mb-4"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            EXECUTION PIPELINE
+          </h2>
+          <div className="flex items-center gap-2 overflow-x-auto pb-1">
+            {phaseOrder.map((phase, idx) => {
+              const isComplete = idx < currentPhaseIdx
+              const isActive = idx === currentPhaseIdx
+              return (
+                <div key={phase} className="flex items-center gap-2 flex-shrink-0">
+                  <div
+                    className={`flex items-center gap-1.5 px-3 py-2 rounded-lg text-xs font-bold uppercase tracking-wider ${
+                      isComplete
+                        ? 'bg-[#22c55e22] text-[#22c55e] border border-[#22c55e44]'
+                        : isActive
+                        ? 'bg-[#3b82f622] text-[#3b82f6] border-2 border-[#3b82f6]'
+                        : 'bg-[#0a0a0a] text-[#555555] border border-[#222222]'
+                    }`}
+                    style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                  >
+                    {isComplete && <Check size={11} />}
+                    {phase}
+                  </div>
+                  {idx < phaseOrder.length - 1 && (
+                    <ChevronRight
+                      size={14}
+                      className={isComplete ? 'text-[#22c55e]' : 'text-[#333333]'}
+                    />
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        </div>
+
+        {/* Progress */}
+        {tasks.length > 0 && (
+          <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
+            <div className="flex items-center justify-between mb-4">
+              <h2
+                className="text-sm font-bold text-white uppercase tracking-widest"
+                style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+              >
+                BUILD PROGRESS ({completedTasks}/{tasks.length})
+              </h2>
+              <span className="text-xs text-[#888888]">{progress}%</span>
+            </div>
+            <div className="h-1.5 bg-[#1a1a1a] rounded-full mb-6 overflow-hidden">
+              <div
+                className="h-full bg-[#3b82f6] rounded-full"
+                style={{ width: `${progress}%` }}
+              />
+            </div>
+            <div className="space-y-2">
+              {tasks
+                .filter((t) => t.status === 'done')
+                .map((task) => (
+                  <div
+                    key={task.id}
+                    className="flex items-start gap-3 bg-[#22c55e08] rounded-lg px-3 py-2.5"
+                  >
+                    <div className="flex-shrink-0 w-4 h-4 rounded bg-[#22c55e] flex items-center justify-center mt-0.5">
+                      <Check size={9} className="text-white" />
+                    </div>
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-[#888888] line-through">{task.title}</p>
+                    </div>
+                    {task.actual_hours && (
+                      <span className="text-xs text-[#444444] flex-shrink-0">{task.actual_hours}h</span>
+                    )}
+                  </div>
+                ))}
+              {tasks
+                .filter((t) => t.status !== 'done')
+                .slice(0, 3)
+                .map((task) => (
+                  <div
+                    key={task.id}
+                    className="flex items-center gap-3 bg-[#0a0a0a] rounded-lg px-3 py-2.5"
+                  >
+                    <div className="flex-shrink-0 w-4 h-4 rounded border-2 border-[#333333]" />
+                    <p className="text-sm text-white">{task.title}</p>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* Ship Log */}
+        {ships.length > 0 && (
+          <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
+            <h2
+              className="text-sm font-bold text-white uppercase tracking-widest mb-4"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              SHIPPING LOG ({ships.length} entries)
+            </h2>
+            <div className="space-y-3">
+              {[...ships]
+                .sort((a, b) => new Date(b.ship_date).getTime() - new Date(a.ship_date).getTime())
+                .map((ship) => (
+                  <div key={ship.id} className="flex gap-4 bg-[#0a0a0a] rounded-lg px-4 py-3">
+                    <div className="flex-shrink-0 text-right min-w-[72px]">
+                      <p
+                        className="text-xs text-[#555555] uppercase tracking-wider"
+                        style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                      >
+                        {new Date(ship.ship_date).toLocaleDateString('en-US', {
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </p>
+                    </div>
+                    <p className="text-sm text-[#888888] leading-relaxed">{ship.ship_description}</p>
+                  </div>
+                ))}
+            </div>
+          </div>
+        )}
+
+        {/* CTA */}
+        <div className="bg-[#111111] border border-[#8b5cf644] rounded-xl p-8 text-center">
+          <p
+            className="text-sm font-bold text-white uppercase tracking-widest mb-2"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            Want to ship like this?
+          </p>
+          <p className="text-xs text-[#888888] mb-6 max-w-sm mx-auto">
+            Yacht Labs gives you the framework, accountability, and AI tools to go from idea to shipped product in days.
+          </p>
+          <Link
+            href="/signup"
+            className="inline-flex items-center gap-2 bg-white text-black font-bold text-xs uppercase tracking-widest py-3 px-6 rounded-lg hover:bg-gray-100 transition-colors"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            Start Your Project Free
+            <ChevronRight size={14} />
+          </Link>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <footer className="border-t border-[#1a1a1a] py-6 mt-12">
+        <p className="text-center text-xs text-[#555555]" style={{ fontFamily: 'var(--font-space-mono), monospace' }}>
+          Built with{' '}
+          <Link href="/" className="text-[#8b5cf6] hover:text-[#a78bfa] transition-colors">
+            ✦✦ YACHT LABS
+          </Link>{' '}
+          · Think · Build · Ship · Listen · Repeat
+        </p>
+      </footer>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -32,6 +32,16 @@ export default function LandingPage() {
             workbench for your next big move.
           </p>
 
+          {/* Loom walkthrough */}
+          <div className="relative w-full max-w-3xl mx-auto mb-12 rounded-xl overflow-hidden border border-[#222222]" style={{ paddingBottom: '56.25%', height: 0 }}>
+            <iframe
+              src="https://www.loom.com/embed/78991d02ed934b98916c7c7d9d98c9b9"
+              frameBorder="0"
+              allowFullScreen
+              style={{ position: 'absolute', top: 0, left: 0, width: '100%', height: '100%' }}
+            />
+          </div>
+
           {/* Try Demo */}
           <div className="mb-6">
             <Link

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,39 +1,135 @@
 import Link from 'next/link'
-import { Mail } from 'lucide-react'
+import { Mail, ChevronRight, Check } from 'lucide-react'
+
+const phases = [
+  {
+    num: '01',
+    name: 'Think',
+    days: 'Day 1–2',
+    color: '#8b5cf6',
+    desc: 'Stop overthinking. AI scopes your MVP in 30 minutes — core features, tech stack, timeline, risks.',
+  },
+  {
+    num: '02',
+    name: 'Build',
+    days: 'Day 3–5',
+    color: '#3b82f6',
+    desc: 'Break it into tasks. AI generates starter code. You ship progress every single day.',
+  },
+  {
+    num: '03',
+    name: 'Ship',
+    days: 'Day 6',
+    color: '#f97316',
+    desc: 'Pre-flight checklist. One-click deploy to Vercel. Your product is live — no DevOps stress.',
+  },
+  {
+    num: '04',
+    name: 'Listen',
+    days: 'Day 7+',
+    color: '#22c55e',
+    desc: 'Track what matters. AI spots patterns. Real user feedback, not vanity metrics.',
+  },
+  {
+    num: '05',
+    name: 'Repeat',
+    days: 'Ongoing',
+    color: '#f59e0b',
+    desc: 'AI prioritizes your next iteration. Ship improvements weekly, not monthly.',
+  },
+]
+
+const socialProof = [
+  {
+    project: 'TaskFlow',
+    by: '@sarah',
+    days: 5,
+    quote: 'Yacht Labs stopped me from overengineering. Just ship the MVP.',
+  },
+  {
+    project: 'InvoiceFlow',
+    by: '@mike',
+    days: 7,
+    quote: 'The daily check-ins kept me honest. 12-day streak and counting.',
+  },
+  {
+    project: 'LinkVault',
+    by: '@alex',
+    days: 3,
+    quote: 'Built this to solve my own problem. Now helping others ship faster.',
+  },
+]
 
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-[#0a0a0a] flex flex-col">
       {/* Top nav */}
-      <nav className="p-6">
+      <nav className="flex items-center justify-between px-6 py-5">
         <span
           className="text-xs font-bold tracking-widest uppercase text-white"
           style={{ fontFamily: 'var(--font-space-mono), monospace' }}
         >
           ✦✦ YACHT LABS
         </span>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/demo"
+            className="text-xs text-[#888888] hover:text-white transition-colors uppercase tracking-widest hidden sm:inline"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            Try Demo
+          </Link>
+          <Link
+            href="/login"
+            className="text-xs text-[#888888] hover:text-white transition-colors uppercase tracking-widest"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            Log in
+          </Link>
+        </div>
       </nav>
 
       {/* Hero */}
-      <main className="flex-1 flex flex-col items-center justify-center px-6 text-center">
+      <main className="flex-1 flex flex-col items-center justify-center px-6 text-center pt-8 pb-16">
         <div className="max-w-4xl w-full">
-          {/* Big heading */}
+          {/* Pill label */}
+          <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-[#8b5cf622] border border-[#8b5cf644] rounded-full mb-8">
+            <span className="w-1.5 h-1.5 rounded-full bg-[#8b5cf6]" />
+            <span
+              className="text-xs text-[#8b5cf6] uppercase tracking-widest font-bold"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              The 5-Phase Shipping Framework
+            </span>
+          </div>
+
+          {/* Heading */}
           <h1
-            className="text-6xl sm:text-7xl md:text-8xl lg:text-9xl font-bold text-white leading-none tracking-tight mb-8"
+            className="text-5xl sm:text-7xl md:text-8xl font-bold text-white leading-none tracking-tight mb-6"
             style={{ fontFamily: 'var(--font-space-mono), monospace' }}
           >
-            <span className="block">BUILD IT.</span>
-            <span className="block">SHIP IT. DONE.</span>
+            <span className="block">STOP PLANNING.</span>
+            <span className="block">START SHIPPING.</span>
           </h1>
 
           {/* Subtitle */}
-          <p className="text-[#888888] text-lg sm:text-xl max-w-xl mx-auto mb-12 leading-relaxed">
-            Stop pushing pixels and start onboarding users. Yacht Labs is the
-            workbench for your next big move.
+          <p className="text-[#888888] text-lg sm:text-xl max-w-xl mx-auto mb-8 leading-relaxed">
+            The proven framework that takes indie hackers from idea → live product in 7 days.
+            AI assistance, daily accountability, and a community of builders who actually ship.
           </p>
 
+          {/* Stats bar */}
+          <div className="flex flex-wrap items-center justify-center gap-6 mb-10 text-xs text-[#555555]" style={{ fontFamily: 'var(--font-space-mono), monospace' }}>
+            <span className="flex items-center gap-1.5"><Check size={11} className="text-[#22c55e]" /> 147 products shipped this month</span>
+            <span className="flex items-center gap-1.5"><Check size={11} className="text-[#22c55e]" /> Avg. time to ship: 6.2 days</span>
+            <span className="flex items-center gap-1.5"><Check size={11} className="text-[#22c55e]" /> 89% completion rate</span>
+          </div>
+
           {/* Loom walkthrough */}
-          <div className="relative w-full max-w-3xl mx-auto mb-12 rounded-xl overflow-hidden border border-[#222222]" style={{ paddingBottom: '56.25%', height: 0 }}>
+          <div
+            className="relative w-full max-w-3xl mx-auto mb-10 rounded-xl overflow-hidden border border-[#222222]"
+            style={{ paddingBottom: '56.25%', height: 0 }}
+          >
             <iframe
               src="https://www.loom.com/embed/78991d02ed934b98916c7c7d9d98c9b9"
               frameBorder="0"
@@ -42,61 +138,196 @@ export default function LandingPage() {
             />
           </div>
 
-          {/* Try Demo */}
-          <div className="mb-6">
+          {/* Primary CTAs */}
+          <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mb-4">
             <Link
               href="/demo"
-              className="inline-flex items-center gap-2 px-6 py-3 bg-[#8b5cf6] text-white font-bold text-sm uppercase tracking-widest rounded-lg hover:bg-[#7c3aed] transition-colors"
+              className="flex items-center gap-2 px-6 py-3 bg-[#8b5cf6] text-white font-bold text-sm uppercase tracking-widest rounded-lg hover:bg-[#7c3aed] transition-colors"
               style={{ fontFamily: 'var(--font-space-mono), monospace' }}
             >
               Try Demo →
             </Link>
-            <p className="text-[#555555] text-xs mt-2">No signup required</p>
+            <Link
+              href="/signup"
+              className="flex items-center gap-2 px-6 py-3 bg-white text-black font-bold text-sm uppercase tracking-widest rounded-lg hover:bg-gray-100 transition-colors"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              Start Shipping Free
+              <ChevronRight size={14} />
+            </Link>
           </div>
+          <p className="text-[#444444] text-xs">No credit card required · Demo needs no signup</p>
 
-          {/* Buttons */}
-          <div className="flex flex-col items-center gap-4 max-w-xs mx-auto">
-            {/* Google button */}
+          {/* Auth links */}
+          <div className="flex flex-col items-center gap-3 max-w-xs mx-auto mt-8">
             <Link
               href="/login"
-              className="w-full flex items-center justify-center gap-3 bg-white text-black font-semibold py-3 px-6 rounded-lg hover:bg-gray-100 transition-colors"
+              className="w-full flex items-center justify-center gap-3 bg-[#111111] text-white text-sm font-medium py-3 px-6 rounded-lg border border-[#222222] hover:bg-[#1a1a1a] transition-colors"
             >
-              {/* Google G icon */}
-              <svg width="18" height="18" viewBox="0 0 18 18" fill="none">
-                <path
-                  d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
-                  fill="#4285F4"
-                />
-                <path
-                  d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"
-                  fill="#34A853"
-                />
-                <path
-                  d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
-                  fill="#FBBC05"
-                />
-                <path
-                  d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
-                  fill="#EA4335"
-                />
+              <svg width="16" height="16" viewBox="0 0 18 18" fill="none">
+                <path d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" fill="#4285F4" />
+                <path d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z" fill="#34A853" />
+                <path d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" fill="#FBBC05" />
+                <path d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" fill="#EA4335" />
               </svg>
               Continue with Google
             </Link>
-
-            {/* Email button */}
             <Link
               href="/login"
-              className="w-full flex items-center justify-center gap-3 bg-[#1a1a1a] text-white font-semibold py-3 px-6 rounded-lg border border-[#333333] hover:bg-[#222222] transition-colors"
+              className="w-full flex items-center justify-center gap-3 bg-[#111111] text-white text-sm font-medium py-3 px-6 rounded-lg border border-[#222222] hover:bg-[#1a1a1a] transition-colors"
             >
-              <Mail size={18} />
+              <Mail size={16} />
               Sign up with email
             </Link>
           </div>
         </div>
       </main>
 
-      {/* Footer hint */}
-      <footer className="p-6 text-center">
+      {/* How It Works */}
+      <section className="px-6 py-16 border-t border-[#1a1a1a]">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-12">
+            <p
+              className="text-xs text-[#555555] uppercase tracking-widest mb-3"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              THE FRAMEWORK
+            </p>
+            <h2
+              className="text-2xl sm:text-3xl font-bold text-white uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              5 PHASES. 7 DAYS. SHIPPED.
+            </h2>
+            <p className="text-[#888888] text-sm mt-3 max-w-md mx-auto">
+              The framework keeps you moving. AI removes friction. Community keeps you accountable.
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {phases.map((phase, idx) => (
+              <div
+                key={phase.num}
+                className="flex items-start gap-5 bg-[#111111] border border-[#222222] rounded-xl p-5 hover:border-[#2a2a2a] transition-colors"
+              >
+                <div className="flex-shrink-0 text-center">
+                  <span
+                    className="text-xs font-bold uppercase tracking-widest"
+                    style={{ color: phase.color, fontFamily: 'var(--font-space-mono), monospace' }}
+                  >
+                    {phase.num}
+                  </span>
+                </div>
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline gap-3 mb-1 flex-wrap">
+                    <span
+                      className="text-sm font-bold text-white uppercase tracking-widest"
+                      style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                    >
+                      {phase.name}
+                    </span>
+                    <span
+                      className="text-xs px-2 py-0.5 rounded"
+                      style={{
+                        backgroundColor: `${phase.color}22`,
+                        color: phase.color,
+                        fontFamily: 'var(--font-space-mono), monospace',
+                      }}
+                    >
+                      {phase.days}
+                    </span>
+                  </div>
+                  <p className="text-sm text-[#888888] leading-relaxed">{phase.desc}</p>
+                </div>
+                {idx < phases.length - 1 && (
+                  <div className="hidden sm:flex flex-shrink-0 items-center">
+                    <ChevronRight size={14} className="text-[#333333]" />
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <div className="mt-8 text-center">
+            <Link
+              href="/demo"
+              className="inline-flex items-center gap-2 text-xs text-[#8b5cf6] hover:text-[#a78bfa] uppercase tracking-widest transition-colors"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              See the framework in action →
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* Social Proof */}
+      <section className="px-6 py-16 border-t border-[#1a1a1a]">
+        <div className="max-w-4xl mx-auto">
+          <div className="text-center mb-10">
+            <p
+              className="text-xs text-[#555555] uppercase tracking-widest mb-3"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              SHIPPED PROJECTS
+            </p>
+            <h2
+              className="text-2xl font-bold text-white uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              BUILDERS WHO ACTUALLY SHIP
+            </h2>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            {socialProof.map((item) => (
+              <div
+                key={item.project}
+                className="bg-[#111111] border border-[#222222] rounded-xl p-5 flex flex-col gap-4"
+              >
+                <div className="flex items-center justify-between">
+                  <div>
+                    <p
+                      className="text-sm font-bold text-white uppercase tracking-wider"
+                      style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                    >
+                      {item.project}
+                    </p>
+                    <p className="text-xs text-[#555555] mt-0.5">{item.by}</p>
+                  </div>
+                  <span
+                    className="text-xs font-bold px-2 py-0.5 rounded bg-[#22c55e22] text-[#22c55e]"
+                    style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                  >
+                    {item.days}d
+                  </span>
+                </div>
+                <p className="text-xs text-[#888888] leading-relaxed flex-1">
+                  &ldquo;{item.quote}&rdquo;
+                </p>
+                <div className="h-1 bg-[#1a1a1a] rounded-full overflow-hidden">
+                  <div className="h-full bg-[#22c55e] rounded-full w-full" />
+                </div>
+              </div>
+            ))}
+          </div>
+
+          {/* Final CTA */}
+          <div className="mt-12 text-center">
+            <Link
+              href="/signup"
+              className="inline-flex items-center gap-2 bg-white text-black font-bold text-sm uppercase tracking-widest py-4 px-8 rounded-lg hover:bg-gray-100 transition-colors"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              Start Your Project Free
+              <ChevronRight size={14} />
+            </Link>
+            <p className="text-[#444444] text-xs mt-3">Join 147 builders shipping this month</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="p-6 text-center border-t border-[#1a1a1a]">
         <p className="text-[#555555] text-xs tracking-wider uppercase" style={{ fontFamily: 'var(--font-space-mono), monospace' }}>
           Think · Build · Ship · Listen · Repeat
         </p>

--- a/components/projects/PublicToggle.tsx
+++ b/components/projects/PublicToggle.tsx
@@ -1,0 +1,120 @@
+'use client'
+
+import { useState } from 'react'
+import { Globe, Copy } from 'lucide-react'
+
+interface Project {
+  id: string
+  name: string
+  is_public?: boolean
+  slug?: string | null
+}
+
+function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)/g, '')
+    .slice(0, 60)
+}
+
+export default function PublicToggle({ project }: { project: Project }) {
+  const [isPublic, setIsPublic] = useState(project.is_public ?? false)
+  const [slug, setSlug] = useState(project.slug ?? generateSlug(project.name))
+  const [loading, setLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const publicUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/p/${slug}`
+
+  const handleToggle = async () => {
+    setLoading(true)
+    const newState = !isPublic
+    const res = await fetch(`/api/projects/${project.id}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_public: newState, slug }),
+    })
+    if (res.ok) setIsPublic(newState)
+    setLoading(false)
+  }
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(publicUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const handleTweet = () => {
+    const text = `Just shipped ${project.name} with @yachtlabs! 🚀`
+    window.open(
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(publicUrl)}`,
+      '_blank'
+    )
+  }
+
+  return (
+    <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <Globe size={14} className={isPublic ? 'text-[#22c55e]' : 'text-[#555555]'} />
+          <div>
+            <p
+              className="text-xs font-bold text-white uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              PUBLIC PROJECT PAGE
+            </p>
+            <p className="text-xs text-[#555555] mt-0.5">
+              Share your execution timeline publicly
+            </p>
+          </div>
+        </div>
+
+        <button
+          onClick={handleToggle}
+          disabled={loading}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+            isPublic ? 'bg-[#22c55e]' : 'bg-[#333333]'
+          }`}
+          aria-label={isPublic ? 'Make private' : 'Make public'}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              isPublic ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      {isPublic && (
+        <div className="bg-[#0a0a0a] border border-[#222222] rounded-lg p-3 space-y-3">
+          <p
+            className="text-xs text-[#555555] uppercase tracking-widest"
+            style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+          >
+            PUBLIC URL
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs text-[#888888] truncate">/p/{slug}</code>
+            <button
+              onClick={handleCopy}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#1a1a1a] border border-[#222222] text-xs text-[#888888] hover:text-white rounded-lg transition-colors"
+            >
+              <Copy size={11} />
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+            <button
+              onClick={handleTweet}
+              className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#1a1a1a] border border-[#222222] text-xs text-[#888888] hover:text-white rounded-lg transition-colors"
+            >
+              <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor">
+                <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/>
+              </svg>
+              Tweet
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/public/PhaseTimeline.tsx
+++ b/components/public/PhaseTimeline.tsx
@@ -1,0 +1,59 @@
+const phases = [
+  { id: 'think', name: 'Think', icon: '🧠' },
+  { id: 'build', name: 'Build', icon: '🔨' },
+  { id: 'ship',  name: 'Ship',  icon: '🚀' },
+  { id: 'listen', name: 'Listen', icon: '👂' },
+  { id: 'repeat', name: 'Repeat', icon: '🔄' },
+]
+
+export default function PhaseTimeline({ project }: { project: { phase: string } }) {
+  const currentPhaseIndex = phases.findIndex((p) => p.id === project.phase)
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-xl p-6">
+      <div className="flex items-start justify-between overflow-x-auto pb-1">
+        {phases.map((phase, index) => {
+          const isComplete = index < currentPhaseIndex
+          const isCurrent = index === currentPhaseIndex
+          const isPending = index > currentPhaseIndex
+
+          return (
+            <div key={phase.id} className="flex items-center flex-1 min-w-0">
+              <div className="flex flex-col items-center flex-shrink-0">
+                <div
+                  className={`w-12 h-12 rounded-full flex items-center justify-center text-xl mb-2 transition-all ${
+                    isComplete
+                      ? 'bg-green-100 ring-2 ring-green-500'
+                      : isCurrent
+                      ? 'bg-purple-100 ring-2 ring-purple-500 scale-110'
+                      : 'bg-gray-100'
+                  }`}
+                >
+                  {phase.icon}
+                </div>
+                <span
+                  className={`text-xs font-medium ${
+                    isCurrent ? 'text-purple-600' : isComplete ? 'text-green-600' : 'text-gray-400'
+                  }`}
+                >
+                  {phase.name}
+                </span>
+                {isComplete && <span className="text-[10px] text-green-600 mt-0.5">✓ Done</span>}
+                {isCurrent && <span className="text-[10px] text-purple-600 mt-0.5">Active</span>}
+                {isPending && <span className="text-[10px] text-gray-400 mt-0.5">Upcoming</span>}
+              </div>
+
+              {index < phases.length - 1 && (
+                <div
+                  className={`flex-1 h-0.5 mx-2 ${
+                    index < currentPhaseIndex ? 'bg-green-500' : 'bg-gray-200'
+                  }`}
+                />
+              )}
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/components/public/PublicProjectView.tsx
+++ b/components/public/PublicProjectView.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import Link from 'next/link'
+import { Calendar, Clock, Eye, TrendingUp } from 'lucide-react'
+import ViewTracker from './ViewTracker'
+import ShareButtons from './ShareButtons'
+import PhaseTimeline from './PhaseTimeline'
+import TaskList from './TaskList'
+import ShippingLog from './ShippingLog'
+
+interface Task {
+  id: string
+  title: string
+  description?: string
+  phase: string
+  status: string
+  priority: string
+  estimated_hours: number
+  actual_hours?: number
+  completed_at?: string
+  ai_generated?: boolean
+  order_index?: number
+}
+
+interface DailyShip {
+  id: string
+  ship_description: string
+  ship_date: string
+}
+
+interface Project {
+  id: string
+  name: string
+  description?: string
+  phase: string
+  status?: string
+  slug: string
+  created_at: string
+  ship_date?: string
+  view_count?: number
+  shared_count?: number
+  current_streak?: number
+  tech_stack?: Record<string, string>
+  tasks: Task[]
+  daily_ships: DailyShip[]
+}
+
+export default function PublicProjectView({ project }: { project: Project }) {
+  const completedTasks = project.tasks?.filter((t) => t.status === 'done').length ?? 0
+  const totalTasks = project.tasks?.length ?? 0
+  const progress = totalTasks > 0 ? Math.round((completedTasks / totalTasks) * 100) : 0
+
+  const startDate = new Date(project.created_at)
+  const daysElapsed = Math.floor((Date.now() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+  const isShipped = project.phase === 'listen' || project.phase === 'repeat'
+  const shipDate = project.ship_date ? new Date(project.ship_date) : null
+  const timeToShip =
+    isShipped && shipDate
+      ? Math.floor((shipDate.getTime() - startDate.getTime()) / (1000 * 60 * 60 * 24))
+      : null
+
+  const totalHours = project.tasks?.reduce(
+    (sum, t) => sum + (t.actual_hours ?? t.estimated_hours ?? 0),
+    0
+  ) ?? 0
+
+  const completedTaskList = project.tasks
+    ?.filter((t) => t.status === 'done')
+    .sort((a, b) => (a.order_index ?? 0) - (b.order_index ?? 0)) ?? []
+
+  const sortedShips = [...(project.daily_ships ?? [])].sort(
+    (a, b) => new Date(b.ship_date).getTime() - new Date(a.ship_date).getTime()
+  )
+
+  return (
+    <>
+      <ViewTracker slug={project.slug} />
+
+      <div className="min-h-screen bg-gray-50">
+        {/* Hero */}
+        <div className="bg-gradient-to-br from-purple-600 via-purple-700 to-blue-600 text-white">
+          <div className="max-w-5xl mx-auto px-6 py-16">
+            <div className="inline-flex items-center gap-2 px-3 py-1.5 bg-white/20 backdrop-blur-sm rounded-full text-sm mb-5">
+              <TrendingUp size={14} />
+              <span>Shipped with Yacht Labs</span>
+            </div>
+
+            <h1 className="text-4xl sm:text-5xl font-bold mb-4 leading-tight">{project.name}</h1>
+
+            {project.description && (
+              <p className="text-lg text-purple-100 mb-8 max-w-2xl leading-relaxed">
+                {project.description}
+              </p>
+            )}
+
+            <div className="flex flex-wrap items-center gap-5 text-sm text-purple-100">
+              <span className="flex items-center gap-2">
+                <Calendar size={14} className="text-purple-200" />
+                {isShipped && timeToShip != null
+                  ? `Shipped in ${timeToShip} days`
+                  : `Building for ${daysElapsed} day${daysElapsed !== 1 ? 's' : ''}`}
+              </span>
+              <span className="flex items-center gap-2">
+                <Clock size={14} className="text-purple-200" />
+                {totalHours}h total
+              </span>
+              <span className="flex items-center gap-2">
+                <TrendingUp size={14} className="text-purple-200" />
+                {progress}% complete
+              </span>
+              {(project.view_count ?? 0) > 0 && (
+                <span className="flex items-center gap-2">
+                  <Eye size={14} className="text-purple-200" />
+                  {project.view_count} views
+                </span>
+              )}
+              {(project.current_streak ?? 0) > 0 && (
+                <span>🔥 {project.current_streak}-day streak</span>
+              )}
+            </div>
+
+            <div className="mt-8">
+              <ShareButtons project={project} />
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="max-w-5xl mx-auto px-6 py-12 space-y-12">
+          {/* Phase Timeline */}
+          <section>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">Execution Timeline</h2>
+            <PhaseTimeline project={project} />
+          </section>
+
+          {/* Tech Stack */}
+          {project.tech_stack && Object.keys(project.tech_stack).length > 0 && (
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">Tech Stack</h2>
+              <div className="flex flex-wrap gap-3">
+                {Object.entries(project.tech_stack).map(([key, value]) => (
+                  <div
+                    key={key}
+                    className="px-4 py-2 bg-white border border-gray-200 rounded-lg text-sm"
+                  >
+                    <span className="text-gray-500 capitalize">{key}:</span>
+                    <span className="ml-1.5 font-medium text-gray-900">{value}</span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          )}
+
+          {/* Completed Tasks */}
+          {completedTaskList.length > 0 && (
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                Completed Tasks ({completedTasks}/{totalTasks})
+              </h2>
+              <TaskList tasks={completedTaskList} />
+            </section>
+          )}
+
+          {/* Shipping Log */}
+          {sortedShips.length > 0 && (
+            <section>
+              <h2 className="text-xl font-semibold text-gray-900 mb-4">
+                Shipping Log ({sortedShips.length} entries)
+              </h2>
+              <ShippingLog ships={sortedShips} />
+            </section>
+          )}
+
+          {/* CTA */}
+          <section>
+            <div className="relative overflow-hidden bg-gradient-to-br from-purple-50 via-blue-50 to-purple-50 border-2 border-purple-200 rounded-2xl p-10 text-center">
+              <div className="absolute top-0 right-0 -mt-12 -mr-12 w-40 h-40 bg-purple-200 rounded-full opacity-20 blur-3xl pointer-events-none" />
+              <div className="absolute bottom-0 left-0 -mb-12 -ml-12 w-40 h-40 bg-blue-200 rounded-full opacity-20 blur-3xl pointer-events-none" />
+
+              <div className="relative">
+                <div className="text-5xl mb-5">🚀</div>
+                <h3 className="text-2xl font-bold text-gray-900 mb-3">Ready to ship your idea?</h3>
+                <p className="text-gray-600 mb-8 max-w-xl mx-auto leading-relaxed">
+                  Join builders using Yacht Labs to go from idea → shipped product in days, not
+                  months. Framework-driven execution with AI assistance.
+                </p>
+                <div className="flex flex-col sm:flex-row items-center justify-center gap-4">
+                  <Link
+                    href="/demo"
+                    className="px-7 py-3 bg-white border-2 border-purple-600 text-purple-600 font-semibold rounded-lg hover:bg-purple-50 transition-colors"
+                  >
+                    Try Interactive Demo
+                  </Link>
+                  <Link
+                    href="/signup"
+                    className="px-7 py-3 bg-purple-600 text-white font-semibold rounded-lg hover:bg-purple-700 transition-colors"
+                  >
+                    Start Your Project →
+                  </Link>
+                </div>
+                <p className="mt-5 text-sm text-gray-500">Free to start · No credit card required</p>
+              </div>
+            </div>
+          </section>
+        </div>
+
+        {/* Footer */}
+        <footer className="border-t bg-white py-10 mt-8">
+          <div className="max-w-5xl mx-auto px-6 flex flex-col sm:flex-row items-center justify-between gap-4">
+            <div>
+              <p className="text-gray-900 font-medium">
+                Built with{' '}
+                <Link href="/" className="text-purple-600 hover:text-purple-700 font-semibold">
+                  Yacht Labs
+                </Link>
+              </p>
+              <p className="text-sm text-gray-500 mt-0.5">
+                Think → Build → Ship → Listen → Repeat
+              </p>
+            </div>
+            <div className="flex gap-5 text-sm text-gray-500">
+              <Link href="/demo" className="hover:text-gray-900 transition-colors">Demo</Link>
+              <Link href="/signup" className="text-purple-600 hover:text-purple-700 font-medium transition-colors">
+                Start Building
+              </Link>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </>
+  )
+}

--- a/components/public/ShareButtons.tsx
+++ b/components/public/ShareButtons.tsx
@@ -1,0 +1,86 @@
+'use client'
+
+import { useState } from 'react'
+import { Link2, Check } from 'lucide-react'
+
+interface Props {
+  project: { name: string; slug: string }
+}
+
+function XIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z" />
+    </svg>
+  )
+}
+
+function LinkedInIcon() {
+  return (
+    <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z" />
+    </svg>
+  )
+}
+
+export default function ShareButtons({ project }: Props) {
+  const [copied, setCopied] = useState(false)
+  const url = typeof window !== 'undefined'
+    ? `${window.location.origin}/p/${project.slug}`
+    : `/p/${project.slug}`
+
+  const trackShare = (platform: string) => {
+    fetch(`/api/projects/${project.slug}/share`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ platform }),
+    })
+  }
+
+  const shareToX = () => {
+    trackShare('twitter')
+    const text = `Just shipped ${project.name} using @yachtlabs! Check out the execution timeline:`
+    window.open(
+      `https://twitter.com/intent/tweet?text=${encodeURIComponent(text)}&url=${encodeURIComponent(url)}`,
+      '_blank',
+      'width=550,height=420'
+    )
+  }
+
+  const shareToLinkedIn = () => {
+    trackShare('linkedin')
+    window.open(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(url)}`,
+      '_blank',
+      'width=550,height=420'
+    )
+  }
+
+  const copyLink = async () => {
+    trackShare('copy')
+    await navigator.clipboard.writeText(url)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  const btnClass =
+    'flex items-center gap-2 px-4 py-2 bg-white/10 hover:bg-white/20 backdrop-blur-sm rounded-lg transition-colors text-sm font-medium'
+
+  return (
+    <div className="flex items-center gap-3 flex-wrap">
+      <span className="text-sm text-purple-200">Share:</span>
+
+      <button onClick={shareToX} className={btnClass}>
+        <XIcon /> X / Twitter
+      </button>
+
+      <button onClick={shareToLinkedIn} className={btnClass}>
+        <LinkedInIcon /> LinkedIn
+      </button>
+
+      <button onClick={copyLink} className={btnClass}>
+        {copied ? <><Check size={14} /> Copied!</> : <><Link2 size={14} /> Copy Link</>}
+      </button>
+    </div>
+  )
+}

--- a/components/public/ShippingLog.tsx
+++ b/components/public/ShippingLog.tsx
@@ -1,0 +1,30 @@
+interface Ship {
+  id: string
+  ship_description: string
+  ship_date: string
+}
+
+export default function ShippingLog({ ships }: { ships: Ship[] }) {
+  return (
+    <div className="space-y-3">
+      {ships.map((ship) => (
+        <div key={ship.id} className="bg-white border border-gray-200 rounded-xl p-4">
+          <div className="flex items-start gap-3">
+            <span className="text-xl flex-shrink-0">📦</span>
+            <div className="flex-1 min-w-0">
+              <p className="text-xs text-gray-500 mb-1">
+                {new Date(ship.ship_date).toLocaleDateString('en-US', {
+                  weekday: 'short',
+                  month: 'short',
+                  day: 'numeric',
+                  year: 'numeric',
+                })}
+              </p>
+              <p className="text-sm text-gray-900 leading-relaxed">{ship.ship_description}</p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/public/TaskList.tsx
+++ b/components/public/TaskList.tsx
@@ -1,0 +1,64 @@
+import { Clock, Zap, Check } from 'lucide-react'
+
+interface Task {
+  id: string
+  title: string
+  description?: string
+  ai_generated?: boolean
+  actual_hours?: number
+  completed_at?: string
+}
+
+export default function TaskList({ tasks }: { tasks: Task[] }) {
+  return (
+    <div className="space-y-3">
+      {tasks.map((task) => (
+        <div
+          key={task.id}
+          className="bg-white border border-gray-200 rounded-xl p-4 hover:border-purple-200 transition-colors"
+        >
+          <div className="flex items-start gap-3">
+            <div className="mt-0.5 flex-shrink-0">
+              <div className="w-5 h-5 rounded-full bg-green-100 flex items-center justify-center">
+                <Check size={11} className="text-green-600" />
+              </div>
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-start justify-between gap-3 mb-1">
+                <p className="font-medium text-gray-900 text-sm">{task.title}</p>
+                <div className="flex items-center gap-3 text-xs text-gray-500 flex-shrink-0">
+                  {task.ai_generated && (
+                    <span className="flex items-center gap-1 text-purple-600">
+                      <Zap size={11} /> AI
+                    </span>
+                  )}
+                  {task.actual_hours != null && (
+                    <span className="flex items-center gap-1">
+                      <Clock size={11} /> {task.actual_hours}h
+                    </span>
+                  )}
+                </div>
+              </div>
+
+              {task.description && (
+                <p className="text-xs text-gray-500 leading-relaxed">{task.description}</p>
+              )}
+
+              {task.completed_at && (
+                <p className="text-xs text-gray-400 mt-1.5">
+                  Completed{' '}
+                  {new Date(task.completed_at).toLocaleDateString('en-US', {
+                    month: 'short',
+                    day: 'numeric',
+                    year: 'numeric',
+                  })}
+                </p>
+              )}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/components/public/ViewTracker.tsx
+++ b/components/public/ViewTracker.tsx
@@ -1,0 +1,14 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export default function ViewTracker({ slug }: { slug: string }) {
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      fetch(`/api/projects/${slug}/view`, { method: 'POST' })
+    }, 3000)
+    return () => clearTimeout(timer)
+  }, [slug])
+
+  return null
+}

--- a/components/settings/PublicProjectSettings.tsx
+++ b/components/settings/PublicProjectSettings.tsx
@@ -1,0 +1,155 @@
+'use client'
+
+import { useState } from 'react'
+import { Eye, EyeOff, Copy, Check, ExternalLink } from 'lucide-react'
+
+interface Project {
+  id: string
+  name: string
+  is_public?: boolean
+  slug?: string | null
+  view_count?: number
+  shared_count?: number
+}
+
+interface Props {
+  project: Project
+  onUpdate?: (updated: Project) => void
+}
+
+export default function PublicProjectSettings({ project, onUpdate }: Props) {
+  const [isPublic, setIsPublic] = useState(project.is_public ?? false)
+  const [slug, setSlug] = useState(project.slug ?? '')
+  const [loading, setLoading] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const origin = typeof window !== 'undefined' ? window.location.origin : 'https://yacht-labs.com'
+  const publicUrl = `${origin}/p/${slug || 'your-project'}`
+
+  const handleToggle = async () => {
+    setLoading(true)
+    const res = await fetch(`/api/projects/${project.id}/visibility`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_public: !isPublic }),
+    })
+    if (res.ok) {
+      const { project: updated } = await res.json()
+      setIsPublic(updated.is_public)
+      setSlug(updated.slug ?? '')
+      onUpdate?.(updated)
+    }
+    setLoading(false)
+  }
+
+  const copyLink = async () => {
+    await navigator.clipboard.writeText(publicUrl)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }
+
+  return (
+    <div className="bg-[#111111] border border-[#222222] rounded-xl p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-3">
+          {isPublic
+            ? <Eye size={14} className="text-[#22c55e]" />
+            : <EyeOff size={14} className="text-[#555555]" />}
+          <div>
+            <p
+              className="text-xs font-bold text-white uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              PUBLIC PROJECT PAGE
+            </p>
+            <p className="text-xs text-[#555555] mt-0.5">Share your execution timeline</p>
+          </div>
+        </div>
+
+        <button
+          onClick={handleToggle}
+          disabled={loading}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors disabled:opacity-50 ${
+            isPublic ? 'bg-[#22c55e]' : 'bg-[#333333]'
+          }`}
+          aria-label={isPublic ? 'Make private' : 'Make public'}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              isPublic ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+
+      {isPublic && slug && (
+        <div className="space-y-4">
+          {/* URL + actions */}
+          <div className="bg-[#0a0a0a] border border-[#222222] rounded-lg p-3">
+            <p
+              className="text-xs text-[#555555] uppercase tracking-widest mb-2"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              PUBLIC URL
+            </p>
+            <div className="flex items-center gap-2">
+              <code className="flex-1 text-xs text-[#888888] truncate">/p/{slug}</code>
+              <button
+                onClick={copyLink}
+                className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#1a1a1a] border border-[#222222] text-xs text-[#888888] hover:text-white rounded-lg transition-colors"
+              >
+                {copied ? <><Check size={10} /> Copied</> : <><Copy size={10} /> Copy</>}
+              </button>
+              <a
+                href={publicUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="flex items-center gap-1.5 px-2.5 py-1.5 bg-[#1a1a1a] border border-[#222222] text-xs text-[#888888] hover:text-white rounded-lg transition-colors"
+              >
+                <ExternalLink size={10} /> View
+              </a>
+            </div>
+          </div>
+
+          {/* Stats */}
+          <div className="grid grid-cols-2 gap-3">
+            {[
+              { label: 'VIEWS', value: project.view_count ?? 0 },
+              { label: 'SHARES', value: project.shared_count ?? 0 },
+            ].map((s) => (
+              <div key={s.label} className="bg-[#0a0a0a] border border-[#222222] rounded-lg p-3">
+                <p
+                  className="text-xs text-[#555555] uppercase tracking-widest mb-1"
+                  style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                >
+                  {s.label}
+                </p>
+                <p
+                  className="text-2xl font-bold text-white"
+                  style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+                >
+                  {s.value}
+                </p>
+              </div>
+            ))}
+          </div>
+
+          {/* Tips */}
+          <div className="bg-[#8b5cf611] border border-[#8b5cf633] rounded-lg p-3">
+            <p
+              className="text-xs font-bold text-[#8b5cf6] uppercase tracking-widest mb-2"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              SHARING TIPS
+            </p>
+            <ul className="space-y-1 text-xs text-[#8b5cf6] opacity-80">
+              <li>• Share after completing major phases for maximum impact</li>
+              <li>• Great for build-in-public content and portfolios</li>
+              <li>• Each view = someone learning about Yacht Labs</li>
+            </ul>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/components/streak/DailyCheckInModal.tsx
+++ b/components/streak/DailyCheckInModal.tsx
@@ -1,0 +1,92 @@
+'use client'
+
+import { useState } from 'react'
+import { X, Rocket } from 'lucide-react'
+
+interface Props {
+  projectName: string
+  currentStreak: number
+  onClose: () => void
+  onSubmit: (description: string) => Promise<void>
+}
+
+export default function DailyCheckInModal({ projectName, currentStreak, onClose, onSubmit }: Props) {
+  const [description, setDescription] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!description.trim()) return
+    setLoading(true)
+    await onSubmit(description.trim())
+    setLoading(false)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/70 flex items-center justify-center z-50 p-4">
+      <div className="bg-[#111111] border border-[#222222] rounded-xl max-w-md w-full">
+        <div className="flex items-start justify-between p-5 border-b border-[#222222]">
+          <div>
+            <div className="flex items-center gap-2 mb-1">
+              <Rocket size={14} className="text-[#f59e0b]" />
+              <p
+                className="text-xs text-[#f59e0b] uppercase tracking-widest font-bold"
+                style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+              >
+                DAILY SHIP LOG
+              </p>
+            </div>
+            <h3 className="text-white font-semibold">What did you ship today?</h3>
+            <p className="text-xs text-[#555555] mt-0.5">{projectName}</p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 hover:bg-[#1a1a1a] rounded-lg transition-colors mt-0.5"
+          >
+            <X size={14} className="text-[#555555]" />
+          </button>
+        </div>
+
+        {currentStreak > 0 && (
+          <div className="px-5 pt-4">
+            <div className="flex items-center gap-2 bg-[#f59e0b11] border border-[#f59e0b33] rounded-lg px-3 py-2">
+              <span className="text-lg">🔥</span>
+              <p className="text-xs text-[#f59e0b]" style={{ fontFamily: 'var(--font-space-mono), monospace' }}>
+                <strong>{currentStreak}-day streak</strong> — keep it alive!
+              </p>
+            </div>
+          </div>
+        )}
+
+        <form onSubmit={handleSubmit} className="p-5 space-y-4">
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            placeholder="e.g. 'Shipped auth flow and deployed to staging' or 'Fixed 3 bugs and added CSV export'"
+            className="w-full h-28 bg-[#0a0a0a] border border-[#222222] text-white text-sm rounded-lg px-3 py-2.5 resize-none placeholder-[#444444] focus:outline-none focus:border-[#f59e0b] transition-colors"
+            autoFocus
+          />
+
+          <div className="flex items-center justify-between gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="text-xs text-[#555555] hover:text-[#888888] uppercase tracking-wider transition-colors"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              Skip today
+            </button>
+            <button
+              type="submit"
+              disabled={loading || !description.trim()}
+              className="flex items-center gap-2 bg-[#f59e0b] text-black font-bold text-xs uppercase tracking-widest py-2.5 px-5 rounded-lg hover:bg-[#d97706] transition-colors disabled:opacity-50"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              {loading ? 'LOGGING...' : 'LOG SHIP 🚀'}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  )
+}

--- a/components/streak/StreakWidget.tsx
+++ b/components/streak/StreakWidget.tsx
@@ -1,0 +1,61 @@
+interface Props {
+  currentStreak: number
+  longestStreak: number
+}
+
+export default function StreakWidget({ currentStreak, longestStreak }: Props) {
+  const message =
+    currentStreak >= 30 ? '🏆 Legendary. Keep going.'
+    : currentStreak >= 14 ? '⭐ Elite consistency.'
+    : currentStreak >= 7  ? '💪 Great momentum!'
+    : currentStreak >= 3  ? '🔥 Building the habit.'
+    : 'Ship something today to start your streak.'
+
+  return (
+    <div className="bg-[#111111] border border-[#f59e0b33] rounded-xl p-5">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <span className="text-3xl select-none">🔥</span>
+          <div>
+            <p
+              className="text-2xl font-bold text-white"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              {currentStreak}
+              <span className="text-sm font-normal text-[#888888] ml-1">
+                {currentStreak === 1 ? 'day' : 'days'}
+              </span>
+            </p>
+            <p
+              className="text-xs text-[#f59e0b] uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              SHIPPING STREAK
+            </p>
+          </div>
+        </div>
+
+        {longestStreak > 0 && (
+          <div className="text-right">
+            <p
+              className="text-lg font-bold text-[#555555]"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              {longestStreak}
+            </p>
+            <p
+              className="text-xs text-[#444444] uppercase tracking-widest"
+              style={{ fontFamily: 'var(--font-space-mono), monospace' }}
+            >
+              BEST
+            </p>
+          </div>
+        )}
+      </div>
+
+      {currentStreak > 0 && (
+        <p className="text-xs text-[#888888] mt-3 border-t border-[#1a1a1a] pt-3">{message}</p>
+      )}
+    </div>
+  )
+}

--- a/lib/streak/checkInPrompt.ts
+++ b/lib/streak/checkInPrompt.ts
@@ -1,0 +1,30 @@
+export function shouldShowCheckIn(lastShipDate: string | null | undefined): boolean {
+  if (!lastShipDate) return true
+
+  const last = new Date(lastShipDate)
+  const today = new Date()
+
+  last.setHours(0, 0, 0, 0)
+  today.setHours(0, 0, 0, 0)
+
+  return last < today
+}
+
+export function calculateStreak(
+  lastShipDate: string | null | undefined,
+  currentStreak: number
+): number {
+  if (!lastShipDate) return 1
+
+  const last = new Date(lastShipDate)
+  const today = new Date()
+
+  last.setHours(0, 0, 0, 0)
+  today.setHours(0, 0, 0, 0)
+
+  const daysDiff = Math.floor((today.getTime() - last.getTime()) / (1000 * 60 * 60 * 24))
+
+  if (daysDiff === 0) return currentStreak       // already logged today
+  if (daysDiff === 1) return currentStreak + 1   // consecutive day
+  return 1                                        // streak broken, restart at 1
+}

--- a/lib/utils/slugify.ts
+++ b/lib/utils/slugify.ts
@@ -1,0 +1,35 @@
+export function generateSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/[\s_-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60)
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export async function ensureUniqueSlug(
+  supabase: any,
+  baseSlug: string,
+  projectId?: string
+): Promise<string> {
+  let slug = baseSlug
+  let counter = 1
+
+  while (true) {
+    const query = supabase
+      .from('projects')
+      .select('id')
+      .eq('slug', slug)
+
+    if (projectId) query.neq('id', projectId)
+
+    const { data } = await query.maybeSingle()
+
+    if (!data) return slug
+
+    slug = `${baseSlug}-${counter}`
+    counter++
+  }
+}

--- a/supabase-migrations-v2.sql
+++ b/supabase-migrations-v2.sql
@@ -31,16 +31,16 @@ create table if not exists daily_ships (
 
 alter table daily_ships enable row level security;
 
-create policy if not exists "Users see their own ships"
+create policy "Users see their own ships"
   on daily_ships for select
   using (auth.uid() = user_id);
 
-create policy if not exists "Users create their own ships"
+create policy "Users create their own ships"
   on daily_ships for insert
   with check (auth.uid() = user_id);
 
 -- 4. Allow public reads of daily_ships for public projects
-create policy if not exists "Public ships visible for public projects"
+create policy "Public ships visible for public projects"
   on daily_ships for select
   using (
     project_id in (

--- a/supabase-migrations-v2.sql
+++ b/supabase-migrations-v2.sql
@@ -1,6 +1,6 @@
 -- ============================================================
 -- Yacht Labs v2 Migration
--- Run in Supabase SQL Editor → dashboard.supabase.com
+-- Run in Supabase SQL Editor → supabase.com/dashboard/project/_/sql
 -- ============================================================
 
 -- 1. Add streak columns to projects
@@ -11,14 +11,23 @@ alter table projects
 
 -- 2. Add public project fields to projects
 alter table projects
-  add column if not exists is_public   boolean default false,
-  add column if not exists slug        text unique,
-  add column if not exists view_count  integer default 0;
+  add column if not exists is_public    boolean default false,
+  add column if not exists slug         text unique,
+  add column if not exists view_count   integer default 0,
+  add column if not exists shared_count integer default 0;
 
 create index if not exists projects_slug_idx
   on projects(slug) where slug is not null;
 
--- 3. Daily ships log
+create index if not exists projects_public_idx
+  on projects(is_public) where is_public = true;
+
+-- 3. RLS policy so public projects are readable by anyone
+create policy "Public projects are viewable by everyone"
+  on projects for select
+  using (is_public = true);
+
+-- 4. Daily ships log
 create table if not exists daily_ships (
   id               uuid primary key default uuid_generate_v4(),
   user_id          uuid references auth.users not null,
@@ -26,7 +35,7 @@ create table if not exists daily_ships (
   ship_description text not null,
   ship_date        date not null default current_date,
   created_at       timestamptz default now() not null,
-  unique (project_id, ship_date)   -- one log per project per day
+  unique (project_id, ship_date)
 );
 
 alter table daily_ships enable row level security;
@@ -39,7 +48,6 @@ create policy "Users create their own ships"
   on daily_ships for insert
   with check (auth.uid() = user_id);
 
--- 4. Allow public reads of daily_ships for public projects
 create policy "Public ships visible for public projects"
   on daily_ships for select
   using (
@@ -47,3 +55,23 @@ create policy "Public ships visible for public projects"
       select id from projects where is_public = true
     )
   );
+
+-- 5. Atomic view counter (called from /api/projects/[slug]/view)
+create or replace function increment_project_views(project_slug text)
+returns void as $$
+begin
+  update projects
+  set view_count = view_count + 1
+  where slug = project_slug and is_public = true;
+end;
+$$ language plpgsql;
+
+-- 6. Atomic share counter (called from /api/projects/[slug]/share)
+create or replace function increment_project_shares(project_slug text)
+returns void as $$
+begin
+  update projects
+  set shared_count = shared_count + 1
+  where slug = project_slug and is_public = true;
+end;
+$$ language plpgsql;

--- a/supabase-migrations-v2.sql
+++ b/supabase-migrations-v2.sql
@@ -1,0 +1,49 @@
+-- ============================================================
+-- Yacht Labs v2 Migration
+-- Run in Supabase SQL Editor → dashboard.supabase.com
+-- ============================================================
+
+-- 1. Add streak columns to projects
+alter table projects
+  add column if not exists last_ship_date date,
+  add column if not exists current_streak  integer default 0,
+  add column if not exists longest_streak  integer default 0;
+
+-- 2. Add public project fields to projects
+alter table projects
+  add column if not exists is_public   boolean default false,
+  add column if not exists slug        text unique,
+  add column if not exists view_count  integer default 0;
+
+create index if not exists projects_slug_idx
+  on projects(slug) where slug is not null;
+
+-- 3. Daily ships log
+create table if not exists daily_ships (
+  id               uuid primary key default uuid_generate_v4(),
+  user_id          uuid references auth.users not null,
+  project_id       uuid references projects(id) on delete cascade,
+  ship_description text not null,
+  ship_date        date not null default current_date,
+  created_at       timestamptz default now() not null,
+  unique (project_id, ship_date)   -- one log per project per day
+);
+
+alter table daily_ships enable row level security;
+
+create policy if not exists "Users see their own ships"
+  on daily_ships for select
+  using (auth.uid() = user_id);
+
+create policy if not exists "Users create their own ships"
+  on daily_ships for insert
+  with check (auth.uid() = user_id);
+
+-- 4. Allow public reads of daily_ships for public projects
+create policy if not exists "Public ships visible for public projects"
+  on daily_ships for select
+  using (
+    project_id in (
+      select id from projects where is_public = true
+    )
+  );


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Demo flow** — fully-populated `/demo` experience (TaskFlow project across all 5 phases) with phase nav, code preview modal, and signup CTAs; no auth required
- **Landing page overhaul** — new headline, stats bar, "How It Works" section, social proof cards, Loom video embed
- **Daily shipping streaks** — check-in modal fires 3s after opening the build phase, streak widget inline, `/api/ships/log` endpoint with deduplication and streak math
- **Public project pages** — `/p/[slug]` server-rendered pages with pipeline, task progress, ship log, view counter; `PublicToggle` component + `/api/projects/[id]/visibility` endpoint

## ⚠️ Required: run database migration

Before the streak and public-page features will work, run **`supabase-migrations-v2.sql`** in the [Supabase SQL Editor](https://supabase.com/dashboard/project/_/sql):

```sql
-- adds to projects: last_ship_date, current_streak, longest_streak,
--                   is_public, slug, view_count
-- creates: daily_ships table with RLS policies
```

The demo flow and landing page changes work immediately without the migration.

## Test plan

- [ ] `/demo` loads without auth and all 5 phase tabs navigate correctly
- [ ] Build phase code preview modal opens on ⚡ click
- [ ] Landing page shows stats bar, How It Works, and social proof
- [ ] After migration: open a project's build phase — check-in modal appears after 3s if not logged today
- [ ] After migration: `/api/ships/log` returns `{ success, streak, longestStreak }`
- [ ] After migration: toggle `PublicToggle` → project visible at `/p/[slug]`
- [ ] All CTAs link to `/signup`
- [ ] Mobile responsive

https://claude.ai/code/session_011pqcY31xM79Rcwbqi9FPwa
EOF
)